### PR TITLE
#152: fixed the DST problem with the calendar display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rmc-calendar",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "React Mobile Calendar Component(web and react-native)",
   "keywords": [
     "react",

--- a/src/DatePicker.base.tsx
+++ b/src/DatePicker.base.tsx
@@ -115,7 +115,13 @@ export default abstract class DatePicker extends React.Component<PropsType, Stat
         isLastOfMonth: false,
         outOfDate: tick < minDateTime || tick > maxDateTime,
       });
-      currentDay = new Date(currentDay.getTime() + 3600 * 24 * 1000);
+      let nextDay = new Date(currentDay.getTime() + 3600 * 24 * 1000);
+
+      if (nextDay.getDate() === currentDay.getDate()) {
+        nextDay = new Date(nextDay.getTime() + 3600 * 1 * 1000);
+      }
+
+      currentDay = nextDay;
     }
     currentWeek[currentWeek.length - 1].isLastOfMonth = true;
     return weeks;


### PR DESCRIPTION
The fix is a bit of a hack, but I verified that it works as expected. If you run the examples on the antd-mobile documentation site and open the calendar to 2020/11, you'll need the problem. There are two Nov 1 days shown in the calendar.